### PR TITLE
Add specs

### DIFF
--- a/lib/resque/heroku-signals.rb
+++ b/lib/resque/heroku-signals.rb
@@ -6,16 +6,16 @@ Resque::Worker.class_eval do
   def unregister_signal_handlers
     trap('TERM') do
       trap('TERM') do
-        puts "[resque-heroku] received second term signal, throwing term exception"
+        log_with_severity :info, "[resque-heroku] received second term signal, throwing term exception"
 
         trap('TERM') do
-          puts "[resque-heroku] third or more time receiving TERM, ignoring"
+          log_with_severity :info, "[resque-heroku] third or more time receiving TERM, ignoring"
         end
 
         raise Resque::TermException.new("SIGTERM")
       end
 
-      puts "[resque-heroku] received first term signal from heroku, ignoring"
+      log_with_severity :info, "[resque-heroku] received first term signal from heroku, ignoring"
 
     end
 

--- a/spec/resque/heroku_spec.rb
+++ b/spec/resque/heroku_spec.rb
@@ -1,11 +1,75 @@
 require "spec_helper"
+require "securerandom"
+
+class DummyJob
+  def self.perform(uuid)
+    sleep 2
+    FileUtils.touch(uuid)
+  end
+end
 
 RSpec.describe Resque::HerokuSignals do
   it "has a version number" do
     expect(Resque::HerokuSignals::VERSION).not_to be nil
   end
 
-  it "ignores the first TERM signal but raises an exception on the second signal" do
+  context "Signal handling" do
+    before do
+      @uuid = SecureRandom.uuid
+      ENV["TERM_CHILD"] = "1"
 
+      @worker = Resque::Worker.new(:jobs)
+    end
+
+    after do
+      FileUtils.remove(@uuid) if File.exist?(@uuid)
+    end
+
+    it "ignores the first TERM signal" do
+      thread = Thread.new do
+        @worker.work(1)
+      end
+
+      Resque::Job.create(:jobs, DummyJob, @uuid)
+      Process.kill("TERM", get_job_pid(@worker))
+
+      wait condition: ->() { !File.exist?(@uuid) }
+      @worker.shutdown
+      thread.join
+
+      expect(File.exist?(@uuid)).to eq(true)
+    end
+
+    it "ignores the first TERM signal but raises an exception on the second signal" do
+      thread = Thread.new do
+        @worker.work(1)
+      end
+      Resque::Job.create(:jobs, DummyJob, @uuid)
+      pid = get_job_pid(@worker)
+      Process.kill("TERM", pid)
+      sleep 0 # It seems like the second signal isn't received without this
+      Process.kill("TERM", pid)
+
+      @worker.shutdown
+      thread.join
+
+      expect(File.exist?(@uuid)).to eq(false)
+    end
+  end
+end
+
+def get_job_pid(worker)
+  pid = nil
+  wait condition: -> () {
+    pid = worker.instance_variable_get("@child")
+    pid.nil?
+  }
+  pid
+end
+
+def wait(timeout: 5000, condition:)
+  t0 = Time.now
+  while condition.call && ((Time.now - t0) * 1000 < timeout)
+    sleep 0.1
   end
 end


### PR DESCRIPTION
I added 2 small specs, just to make sure that the new signal handling logic worked as expected. I'm not a fan of how I had to write the specs (using a separate thread to run the worker), but it works, which was my initial goal!

I also refactored logging a tiny bit, to make sure it was consistent with how Resque does it and so it can be controller through the verbosity env variables.

PS: Thank you so much for writing this gem 👍 