### PR TITLE
Version 2.3.0 to match Resque

### DIFF
--- a/resque-heroku-signals.gemspec
+++ b/resque-heroku-signals.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "resque-heroku-signals"
-  spec.version       = '2.2.1'
+  spec.version       = '2.3.0'
   spec.authors       = ["Michael Bianco"]
   spec.email         = ["mike@mikebian.co"]
 
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   gem.metadata['rubygems_mfa_required'] = 'true'
 
   # strict resque dependency is intentional
-  spec.add_dependency "resque", "2.2.1"
+  spec.add_dependency "resque", "2.3.0"
 
   spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
Bumps the version in the gemspec to 2.3.0 to match Resque
