### PR TITLE
Add ruby 3.1. and 3.2 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
           - 6379:6379
     strategy:
       matrix:
-        ruby-version: ['3.0', '2.7']
+        ruby-version: ['3.2', '3.1', '3.0', '2.7']
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Heroku supports ruby 3.1 and 3.2 now so they should be added to the test matrix
