### PR TITLE
Let's switch to SIGINT for child termination

### DIFF
--- a/lib/resque-heroku-signals.rb
+++ b/lib/resque-heroku-signals.rb
@@ -12,24 +12,43 @@ end
 #   https://github.com/resque/resque/blame/v2.0.0/lib/resque/worker.rb#L406
 # https://github.com/resque/resque/issues/1559#issuecomment-310908574
 Resque::Worker.class_eval do
-  def unregister_signal_handlers
-    trap('TERM') do
-      $HEROKU_WILL_TERMINATE_RESQUE = true
-
-      trap('TERM') do
-        log_with_severity :info, "[resque-heroku] received second term signal, throwing term exception"
-
-        trap('TERM') do
-          log_with_severity :info, "[resque-heroku] third or more time receiving TERM, ignoring"
+  # In this patched implementation, the only change is that the worker sends
+  # SIGINT to the child, the rest is copied verbatim.
+  def new_kill_child
+    if @child
+      unless child_already_exited?
+        if pre_shutdown_timeout && pre_shutdown_timeout > 0.0
+          log_with_severity :debug, "Waiting #{pre_shutdown_timeout.to_f}s for child process to exit"
+          return if wait_for_child_exit(pre_shutdown_timeout)
         end
 
-        raise Resque::TermException.new("SIGTERM")
-      end
+        log_with_severity :debug, "Sending INT signal to child #{@child}"
+        Process.kill("INT", @child)
 
-      log_with_severity :info, "[resque-heroku] received first term signal from heroku, ignoring"
+        if wait_for_child_exit(term_timeout)
+          return
+        else
+          log_with_severity :debug, "Sending KILL signal to child #{@child}"
+          Process.kill("KILL", @child)
+        end
+      else
+        log_with_severity :debug, "Child #{@child} already quit."
+      end
+    end
+  rescue SystemCallError
+    log_with_severity :error, "Child #{@child} already quit and reaped."
+  end
+
+  def unregister_signal_handlers
+    trap("TERM") do
+      log_with_severity :debug, "Got TERM signal from Heroku."
+      $HEROKU_WILL_TERMINATE_RESQUE = true
     end
 
-    trap('INT', 'DEFAULT')
+    trap("INT") do
+      log_with_severity :debug, "Got INT signal from the worker."
+      raise Resque::TermException.new("SIGINT")
+    end
 
     begin
       trap('QUIT', 'DEFAULT')


### PR DESCRIPTION
## Problem

As the Heroku documentation [says](https://devcenter.heroku.com/articles/dynos#shutdown), processes in dynos being shut down may receive multiple `SIGTERM`s:

> Please note that it is currently possible that processes in a dyno that is being shut down may receive multiple SIGTERMs

I have seen this happening occasionally, and could reproduce synthetically with a simple script by going up & down a few times:

![CleanShot 2023-04-18 at 12 08 12](https://user-images.githubusercontent.com/3387/233049033-fc8c629d-8165-4497-80e7-abbb264cf977.jpg)

The current implementation of this gem is based on the assumption that the first `SIGTERM` comes from Heroku, and the second one from Resque, and as you see this is not necessarily the case. If the child raises on a second `SIGTERM` from Heroku, the logic for `RESQUE_PRE_SHUTDOWN_TIMEOUT` is lost.

## Proposed Solution

In this alternative approach, we also patch `new_kill_child` to send `SIGINT` to the child, instead of `SIGTERM`. That way, we entirely remove the conflict:

1. If the child gets `SIGTERM`, set `$HEROKU_WILL_TERMINATE_RESQUE` to `true` (idempotent).
2. If the child gets `SIGINT`, that is the worker, raise.

The signal handlers get indeed quite simplified and robust this way.

What do you think?

Fixes #13.