### PR TITLE
Version 2.5.0.1

### DIFF
--- a/resque-heroku-signals.gemspec
+++ b/resque-heroku-signals.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "resque-heroku-signals"
-  spec.version       = '2.5.0'
+  spec.version       = '2.5.0.1'
   spec.authors       = ["Michael Bianco"]
   spec.email         = ["mike@mikebian.co"]
 


### PR DESCRIPTION
Version 2.5.0.1 to get a release that is out of band with normal resque releases. I think that's the cleanest way to do it without requiring a simulataneous release of resque.
