### PR TITLE
Version 2.7.0

### DIFF
--- a/resque-heroku-signals.gemspec
+++ b/resque-heroku-signals.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "resque-heroku-signals"
-  spec.version       = '2.6.0'
+  spec.version       = '2.7.0'
   spec.authors       = ["Michael Bianco"]
   spec.email         = ["mike@mikebian.co"]
 
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata['rubygems_mfa_required'] = 'true'
 
   # strict resque dependency is intentional
-  spec.add_dependency "resque", "2.6.0"
+  spec.add_dependency "resque", "2.7.0"
 
   spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
This pull request includes updates to the `resque-heroku-signals.gemspec` file, specifically to upgrade the version of the gem and its dependency on `resque`.

Version updates:

* Updated the gem version from `2.6.0` to `2.7.0` in the `resque-heroku-signals.gemspec` file.
* Updated the `resque` dependency version from `2.6.0` to `2.7.0` in the `resque-heroku-signals.gemspec` file.