### PR TITLE
Add 3.4 and 3.3 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,14 @@ jobs:
           - 6379:6379
     strategy:
       matrix:
-        ruby-version: ['3.2', '3.1', '3.0', '2.7']
+        ruby-version: [
+          '3.4',
+          '3.3',
+          '3.2',
+          '3.1',
+          '3.0',
+          '2.7'
+        ]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request includes updates to the Ruby versions tested in the CI workflow configuration file. The most important change is the addition of new Ruby versions to the test matrix.

Changes to CI configuration:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL13-R20): Updated the `ruby-version` matrix to include Ruby versions `3.4` and `3.3`.